### PR TITLE
Make the riscv trap handler taggable

### DIFF
--- a/FreeRTOS/Source/portable/GCC/RISC-V/portASM.S
+++ b/FreeRTOS/Source/portable/GCC/RISC-V/portASM.S
@@ -197,7 +197,9 @@ at the top of this file. */
   
 .endm
 
+.text
 .align 8
+.global freertos_risc_v_trap_handler
 freertos_risc_v_trap_handler:
 
     /* check for exception */
@@ -410,6 +412,7 @@ processed_source:
 	addi sp, sp, portCONTEXT_SIZE
 
 	mret
+.size freertos_risc_v_trap_handler, [.-freertos_risc_v_trap_handler]
 /*-----------------------------------------------------------*/
 
 .align 8


### PR DESCRIPTION
Ensure that the tagging tools have the information needed to tag the riscv trap handler.