### PR TITLE
Fix FreeRTOS VCU118 bsp to run with policies

### DIFF
--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/BuildEnvironment.mk
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/BuildEnvironment.mk
@@ -35,7 +35,7 @@ ISP_ASMFLAGS += -ffunction-sections -fdata-sections
 ISP_ASMFLAGS += -x assembler-with-cpp
 
 LIBWRAP_SYMS := open lseek read write fstat stat close link unlink \
-	execve fork getpid kill wait isatty times sbrk _exit puts
+	execve fork getpid kill wait isatty times sbrk _exit puts printf
 
 # Linker arguments __________________________________________
 ISP_LDFLAGS := -Xlinker --defsym=__stack_size=1K

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/Makefile
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/Makefile
@@ -40,6 +40,7 @@ SDK_SRC := \
 	$(SDK_DIR)/libwrap/sys/lseek.c \
 	$(SDK_DIR)/libwrap/sys/openat.c \
 	$(SDK_DIR)/libwrap/sys/puts.c \
+	$(SDK_DIR)/libwrap/sys/printf.c \
 	$(SDK_DIR)/libwrap/sys/read.c \
 	$(SDK_DIR)/libwrap/sys/sbrk.c \
 	$(SDK_DIR)/libwrap/sys/stat.c \

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/freedom-e-sdk/libwrap/sys/printf.c
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/freedom-e-sdk/libwrap/sys/printf.c
@@ -1,0 +1,26 @@
+/* See LICENSE of license details. */
+
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include "weak_under_alias.h"
+#include "puts.h"
+
+int __wrap_printf(const char *s, ...)
+{
+    char buf[256];
+    va_list vl;
+
+    const char *p = &buf[0];
+
+    va_start(vl, s);
+    vsnprintf(buf, sizeof buf, s, vl);
+    va_end(vl);
+
+    __wrap_puts(p);
+
+    return 0;
+}
+weak_under_alias(printf);

--- a/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/freedom-e-sdk/libwrap/sys/puts.h
+++ b/FreeRTOS/Demo/RISC-V-Qemu-sifive_e-FreedomStudio/freedom-e-sdk/libwrap/sys/puts.h
@@ -1,0 +1,7 @@
+#ifndef LIBWRAP_PUTS_H
+#define LIBWRAP_PUTS_H
+
+int __wrap_puts(const char *s);
+
+#endif // LIBWRAP_PUTS_H
+

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/Makefile
@@ -84,6 +84,8 @@ APP_SRC = \
 	bsp/gpio.c \
 	bsp/spi.c \
 	bsp/rand.c \
+	bsp/wrap/printf.c \
+	bsp/wrap/puts.c \
 	bsp/xilinx/uartns550/xuartns550.c \
 	bsp/xilinx/uartns550/xuartns550_g.c \
 	bsp/xilinx/uartns550/xuartns550_sinit.c \
@@ -128,6 +130,7 @@ APP_SRC = \
 INCLUDES = \
 	-I. \
 	-I./bsp \
+	-I./bsp/wrap \
 	-I./bsp/xilinx \
 	-I./bsp/xilinx/common \
 	-I./bsp/xilinx/axidma \
@@ -270,6 +273,8 @@ ELF_OBJS = $(DEMO_OBJ)
 
 LDFLAGS	 = -T link.ld -nostartfiles -defsym=_STACK_SIZE=4K
 LDFLAGS  += -Wl,--gc-sections
+LDFLAGS  += -Wl,--wrap=puts
+LDFLAGS  += -Wl,--wrap=printf
 
 LIBS	 =  -lc -lgcc -lfreertos-vcu118 -L.
 

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/weak_under_alias.h
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/weak_under_alias.h
@@ -1,0 +1,2 @@
+#define weak_under_alias(name)                                          \
+    extern __typeof (__wrap_##name) __wrap__##name __attribute__ ((weak, alias ("__wrap_"#name)))

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/wrap/printf.c
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/wrap/printf.c
@@ -1,0 +1,24 @@
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include "weak_under_alias.h"
+#include "puts.h"
+
+int __wrap_printf(const char *s, ...)
+{
+    char buf[256];
+    va_list vl;
+
+    const char *p = &buf[0];
+
+    va_start(vl, s);
+    vsnprintf(buf, sizeof buf, s, vl);
+    va_end(vl);
+
+    __wrap_puts(p);
+
+    return 0;
+}
+weak_under_alias(printf);

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/wrap/puts.c
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/wrap/puts.c
@@ -1,0 +1,23 @@
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include "uart.h"
+#include "weak_under_alias.h"
+
+int __wrap_puts(const char *s)
+{
+  int len = 0;
+  while (*s != '\0') {
+    uart0_txchar(*s);
+
+    if (*s == '\n') {
+      uart0_txchar('\r');
+    }
+
+    ++len;
+    ++s;
+  }
+
+  return len;
+}
+weak_under_alias(puts);

--- a/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/wrap/puts.h
+++ b/FreeRTOS/Demo/RISC-V_Galois_P1/bsp/wrap/puts.h
@@ -1,0 +1,1 @@
+int __wrap_puts(const char *s);

--- a/Makefile.isp
+++ b/Makefile.isp
@@ -21,7 +21,7 @@ INSTALL_BUILD_DIR := $(INSTALL_DIR)/build
 
 all:
 	$(MAKE) -C $(HIFIVE_DIR) lib
-	$(MAKE) -C $(VCU118_DIR) lib
+	CLANG=1 $(MAKE) -C $(VCU118_DIR) lib
 
 install: install-libs install-headers install-build
 


### PR DESCRIPTION
Two fixes:
- Make libfreertos.a compile with clang to support the stack policy
- Add printf and puts wrappers to avoid using newlib printf (which has a NULL pointer dereference bug)